### PR TITLE
fix(select): bad include order

### DIFF
--- a/src/sys/select.c
+++ b/src/sys/select.c
@@ -5,7 +5,7 @@
 ** select
 */
 
-#include <sys/select.h>
 #include "internal.h"
+#include <sys/select.h>
 
 DECL_CLCC_ARGS_5(int, select, int, fd_set *, fd_set *, fd_set *, struct timeval *)


### PR DESCRIPTION
Moved `internal.h` at top to define at top level `__GNU_SOURCE` and allow usage or macro `RTLD_NEXT`.